### PR TITLE
Fix npm publish workflow package name

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,7 +47,7 @@ jobs:
         id: check-version
         run: |
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          if npm view "@arizona-framework/client@${CURRENT_VERSION}" version 2>/dev/null; then
+          if npm view "@arizona-framework/svelte@${CURRENT_VERSION}" version 2>/dev/null; then
             echo "Version ${CURRENT_VERSION} already published, skipping"
             echo "should-publish=false" >> "${GITHUB_OUTPUT}"
           else


### PR DESCRIPTION
Change package name check from @arizona-framework/client to @arizona-framework/svelte in the publish workflow.